### PR TITLE
Fix(wiki/view)

### DIFF
--- a/mos/src/main/resources/static/js/wiki/wikitree-view.js
+++ b/mos/src/main/resources/static/js/wiki/wikitree-view.js
@@ -19,6 +19,8 @@ if (wikiNo == null) {
       ` : ''}
     </div>
   `);
+  $('#contentEditLink').attr('href',
+      '/wiki/edit?studyNo=' + studyNo);
 }
 
 const getListUrl = "/api/wiki?studyNo=" + studyNo;


### PR DESCRIPTION
- wikiNo가 없는 경우에 편집 버튼 주소를 수정함